### PR TITLE
feat: intercept error to display 'em in the UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@edx/frontend-platform": "^7.0.0 || ^8.0.0",
+				"@fortawesome/free-solid-svg-icons": "^6.0.0",
+				"@fortawesome/react-fontawesome": "^0.2.0",
 				"@openedx/frontend-plugin-framework": "^1.0.0",
 				"dompurify": "^3.2.6",
 				"prop-types": "15.8.1"
@@ -2783,6 +2785,64 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/@fortawesome/fontawesome-common-types": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
+			"integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/fontawesome-svg-core": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
+			"integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "7.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-solid-svg-icons": {
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+			"integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+			"license": "(CC-BY-4.0 AND MIT)",
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.7.2"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+			"integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/react-fontawesome": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.6.tgz",
+			"integrity": "sha512-mtBFIi1UsYQo7rYonYFkjgYKGoL8T+fEH6NGUpvuqtY3ytMsAoDaPo5rk25KuMtKDipY4bGYM/CkmCHA1N3FUg==",
+			"deprecated": "v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.",
+			"license": "MIT",
+			"dependencies": {
+				"prop-types": "^15.8.1"
+			},
+			"peerDependencies": {
+				"@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+				"react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@fullhuman/postcss-purgecss": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
 		"@edx/frontend-platform": "^7.0.0 || ^8.0.0",
 		"@openedx/frontend-plugin-framework": "^1.0.0",
 		"dompurify": "^3.2.6",
-		"prop-types": "15.8.1"
+		"prop-types": "15.8.1",
+		"@fortawesome/free-solid-svg-icons": "^6.0.0",
+		"@fortawesome/react-fontawesome": "^0.2.0"
 	},
 	"peerDependencies": {
 		"@edx/frontend-platform": "^7.0.0 || ^8.0.0",

--- a/src/extended-profile/account-fields/elements/BaseField.jsx
+++ b/src/extended-profile/account-fields/elements/BaseField.jsx
@@ -74,8 +74,8 @@ const BaseField = ({
       return renderEmptyLabel();
     }
 
-	// If it is a select field, we want to display the option label instead of the value
-	const fieldOption = fieldOptions?.find((option) => option.value === rawValue);
+    // If it is a select field, we want to display the option label instead of the value
+    const fieldOption = fieldOptions?.find((option) => option.value === rawValue);
     return fieldOption ? fieldOption.name : rawValue;
   };
 
@@ -170,6 +170,7 @@ BaseField.propTypes = {
       label: PropTypes.string.isRequired,
     }),
   ),
+  savingErrors: PropTypes.objectOf(PropTypes.string),
 };
 
 BaseField.defaultProps = {

--- a/src/extended-profile/profile-fields/elements/BaseField.jsx
+++ b/src/extended-profile/profile-fields/elements/BaseField.jsx
@@ -167,6 +167,7 @@ BaseField.propTypes = {
       label: PropTypes.string.isRequired,
     }),
   ),
+  savingErrors: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)),
 };
 
 BaseField.defaultProps = {

--- a/src/extended-profile/profile-fields/index.jsx
+++ b/src/extended-profile/profile-fields/index.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import PropTypes from 'prop-types';
 
 import ExtendedProfileFieldsContext from '../ExtendedProfileContext';
 
@@ -78,6 +79,16 @@ const ProfileFields = ({ fetchProfile, extendedProfileValues }) => {
       })}
     </div>
   );
+};
+
+ProfileFields.propTypes = {
+  fetchProfile: PropTypes.func.isRequired,
+  extendedProfileValues: PropTypes.arrayOf(
+    PropTypes.shape({
+      fieldName: PropTypes.string.isRequired,
+      fieldValue: PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 export default ProfileFields;


### PR DESCRIPTION
This PR adds an interceptor to the httpClient to capture the errors that came from the `v1/accounts/` API  endpoint, aiming to display them in the UI properly and execute some actions in consequence

### How to test
- Have a NAU environment mounted with `nau-tutor-configs` to make use of the validations (in this case `NifValidator`)
- Use this branch to use the interceptor
- Add a mistake in the NIF field
- You'll be able to watch the error, and the field shouldn't be properly saved

### Screencast
[Screencast from 13-02-26 11:37:49.webm](https://github.com/user-attachments/assets/7221ed52-a92a-4275-951d-c15111f292cb)
